### PR TITLE
fix an edge case bug with an ingredient not associated with a section

### DIFF
--- a/HappyFL/ClientApp/src/app/recipes/recipes.component.html
+++ b/HappyFL/ClientApp/src/app/recipes/recipes.component.html
@@ -45,7 +45,7 @@
             <div
               *ngFor="let group of d.ingredientsBySection; let i = index"
               class="row section">
-              <h5>{{group.section.name}}</h5>
+              <h5>{{group.section?.name}}</h5>
               <div
                 class="col-12">
                 <div

--- a/HappyFL/Controllers/RecipeManagementController.cs
+++ b/HappyFL/Controllers/RecipeManagementController.cs
@@ -62,7 +62,7 @@ namespace HappyFL.Controllers
             foreach (var recipe in recipes)
             {
                 recipe.Ingredients = recipe.Ingredients
-                    .OrderBy(i => i.Section.Id)
+                    .OrderBy(i => i.Section?.Id ?? 0)
                     .ThenBy(i => i.Id)
                     .ToList();
             }
@@ -121,6 +121,7 @@ namespace HappyFL.Controllers
             if (recipe.Id < 0)
                 recipe.Id = null;
             sections = recipe.Ingredients
+                .Where(i => i.Section != null)
                 .Select(i => i.Section)
                 .GroupBy(s => s.Id)
                 .Select(g => g.First());
@@ -128,8 +129,9 @@ namespace HappyFL.Controllers
             {
                 if (ingredient.Id < 0)
                     ingredient.Id = null;
-                ingredient.Section = sections
-                    .FirstOrDefault(s => s.Id == ingredient.Section.Id);
+                if (ingredient.Section != null)
+                    ingredient.Section = sections
+                        .FirstOrDefault(s => s.Id == ingredient.Section.Id);
             }
             foreach (var section in sections)
                 if (section.Id < 0)


### PR DESCRIPTION
Fix an edge case, where an ingredient is not associated with an ingredient section.
This never happens if recipe data had been made via Recipe Seeker page.