### PR TITLE
show loading message until both loading saved recipe and scanning recipe complete

### DIFF
--- a/HappyFL/ClientApp/src/app/recipe-seeker/recipe-seeker.component.html
+++ b/HappyFL/ClientApp/src/app/recipe-seeker/recipe-seeker.component.html
@@ -18,6 +18,14 @@
   </div>
 
   <div
+    *ngIf="(loadRecipe$ | async).isLoading"
+    class="row fill-window">
+    <div class="col-12 align-self-center text-center">
+      Loading...
+    </div>
+  </div>
+
+  <div
     *ngIf="(recipeSeekResult$ | async).isCancelled"
     class="row fill-window">
     <div class="col-12 align-self-center">
@@ -28,7 +36,7 @@
   </div>
 
   <div
-    *ngIf="!(recipeSeekResult$ | async).isLoading && !(recipeSeekResult$ | async).isCancelled && (recipeSeekResult$ | async).data"
+    *ngIf="!(loadRecipe$ | async).isLoading && !(recipeSeekResult$ | async).isLoading && !(recipeSeekResult$ | async).isCancelled"
     class="row no-gutters">
     <div class="col-12">
       <div class="form-group">

--- a/HappyFL/ClientApp/src/app/recipe-seeker/recipe-seeker.component.ts
+++ b/HappyFL/ClientApp/src/app/recipe-seeker/recipe-seeker.component.ts
@@ -28,6 +28,10 @@ export class RecipeSeekerComponent implements OnInit {
     ingredients: ScannedIngredient[],
   }[]>;
 
+  public loadRecipe$: Observable<{
+    isLoading: boolean,
+  }>;
+
   public saveRecipe$: Observable<{
     isSaving: boolean,
     isSuccess: boolean,
@@ -81,8 +85,8 @@ export class RecipeSeekerComponent implements OnInit {
       }
     });
 
-    this.store.select(state => state.recipeManagement.recipe)
-      .subscribe(r => {
+    this.loadRecipe$ = this.store.select(state => state.recipeManagement.recipe).pipe(
+      map(r => {
         if (r.isLoading || !r.data)
           return r;
         this.recipe = r.data;
@@ -92,7 +96,8 @@ export class RecipeSeekerComponent implements OnInit {
         this.store.dispatch(requestRecipeSeek({ url: this.recipe.urlOfBase }));
 
         return r;
-      });
+      })
+    );
 
     this.recipeSeekResult$ = this.store.select(state => state.recipeManagement.recipeSeekResult).pipe(
       map(r => {


### PR DESCRIPTION
Use RxJS pipe to request recipe scanning after receiving a saved recipe data.

By doing so, loading message for loading recipe can be shown, and it can also be switched to the loading message for recipe scanning immediately after receiving saved recipe data.